### PR TITLE
fix(serializer): handle non-localized models

### DIFF
--- a/addon/-private/serializers/localized.js
+++ b/addon/-private/serializers/localized.js
@@ -3,7 +3,10 @@ import JSONAPISerializer from "@ember-data/serializer/json-api";
 export default class ScopeSerializer extends JSONAPISerializer {
   serializeAttribute(snapshot, json, key, attributes) {
     super.serializeAttribute(snapshot, json, key, attributes);
-    if (snapshot.record.localizedFields.includes(key)) {
+
+    let { localizedFields = [] } = snapshot.record;
+
+    if (localizedFields.includes(key)) {
       json.attributes[key] = snapshot.record.getUnlocalizedField(key);
     }
   }


### PR DESCRIPTION
Otherwise, we are forced to use a different serializer for non-localized models.