### PR TITLE
feat: make source property name public under new name

### DIFF
--- a/addon/-private/decorators/localized-attr.js
+++ b/addon/-private/decorators/localized-attr.js
@@ -51,7 +51,7 @@ export default function (...args) {
     setter.call(this, attribute);
   };
 
-  Object.defineProperty(target, `_${name}`, {
+  Object.defineProperty(target, `${name}Object`, {
     get() {
       return getter.call(this);
     },

--- a/addon/-private/models/localized.js
+++ b/addon/-private/models/localized.js
@@ -1,4 +1,5 @@
 import Model from "@ember-data/model";
+import { deprecate } from '@ember/debug';
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 
@@ -7,7 +8,16 @@ export default class LocalizedModel extends Model {
   @tracked localizedFieldLocale;
 
   getUnlocalizedField(field) {
-    return this[`_${field}`];
+    deprecate('Usage of `getUnlocalizedField` is deprecated. Access object directly.',
+        false,
+        {
+            id: 'ember-localized-model.public-unlocalized',
+            until: '2.0.0',
+            url: 'https://github.com/projectcaluma/ember-localized-model/pull/101'
+        }
+    );
+
+    return this[`${field}Object`];
   }
 
   getFieldLocale() {


### PR DESCRIPTION
We need this to provide an ember-changeset input for each language.