### PR TITLE
fix(decorators/localized-attr): set default value for new object api

### DIFF
--- a/addon/-private/decorators/localized-attr.js
+++ b/addon/-private/decorators/localized-attr.js
@@ -1,11 +1,15 @@
-import { getOwner } from '@ember/application';
-import { isEmpty } from '@ember/utils';
+import { getOwner } from "@ember/application";
+import { isEmpty } from "@ember/utils";
 import { attr } from "@ember-data/model";
 
 export default function (...args) {
   const [target, name] = args;
 
-  const attrComputed = attr(...args);
+  // We cannot set the `defaultValue` directly to `{}` because of:
+  // Error: Assertion Failed: Non primitive defaultValues are not supported because they are shared
+  // between all instances. If you would like to use a complex object as a default value please
+  // provide a function that returns the complex object.
+  const attrComputed = attr({ defaultValue: () => ({}) })(...args);
   const { get: getter, set: setter } = attrComputed;
 
   target.localizedFields = [...(target.localizedFields || []), name];
@@ -18,20 +22,23 @@ export default function (...args) {
     }
 
     const {
-      localizedModel: { allowAnyFallback = false, fallbacks = [] } = {}
-    } = getOwner(this).resolveRegistration('config:environment');
+      localizedModel: { allowAnyFallback = false, fallbacks = [] } = {},
+    } = getOwner(this).resolveRegistration("config:environment");
 
-    if(value[this.getFieldLocale()] || (!allowAnyFallback && !fallbacks.length)){
+    if (
+      value[this.getFieldLocale()] ||
+      (!allowAnyFallback && !fallbacks.length)
+    ) {
       return value[this.getFieldLocale()];
     }
 
-    let key = fallbacks.find(key => !isEmpty(value[key]));
+    let key = fallbacks.find((key) => !isEmpty(value[key]));
 
     if (!key && allowAnyFallback) {
-      key = Object.keys(value).find(key => !isEmpty(value[key]));
+      key = Object.keys(value).find((key) => !isEmpty(value[key]));
     }
 
-    return value[key]
+    return value[key];
   };
 
   attrComputed.set = function (value) {
@@ -51,13 +58,11 @@ export default function (...args) {
     setter.call(this, attribute);
   };
 
+  // Use the getter and setter for the original property so both
+  // the Object and the previous getter and setter access the same value.
   Object.defineProperty(target, `${name}Object`, {
-    get() {
-      return getter.call(this);
-    },
-    set(value) {
-      setter.call(this, value);
-    },
+    get: getter,
+    set: setter,
   });
 
   return attrComputed;


### PR DESCRIPTION
We added a new api with wich you can access the translation object directly.
This deprecated the `getUnlocalizedField` method.

Now we set the default value to a empty object so on creation of a new model
you dont always have to assign an empty object yourself. This mostly fixes
reference lookup errors like ""[insertYourPropertyName].en was not found".