### PR TITLE
Add tests and remove deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
           - ember-beta
           - ember-canary
           - ember-classic
-          - embroider-safe
-          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you want to switch locale for only one specific model, you can set
 `yourModel.localizedFieldLocale` to the desired locale.
 
 If you want to access the raw data as sent by the backend, you can use
-`yourModel.getUnlocalizedField("firstName")`. This will return the raw data.
+`yourModel.localizedObjects.firstName`. This will return the raw data.
 
 For example:
 

--- a/addon/-private/decorators/localized-attr.js
+++ b/addon/-private/decorators/localized-attr.js
@@ -60,9 +60,10 @@ export default function (...args) {
 
   // Use the getter and setter for the original property so both
   // the Object and the previous getter and setter access the same value.
-  Object.defineProperty(target, `${name}Object`, {
+  Object.defineProperty(target, `_${name}`, {
     get: getter,
     set: setter,
+    enumerable: false,
   });
 
   return attrComputed;

--- a/addon/-private/serializers/localized.js
+++ b/addon/-private/serializers/localized.js
@@ -7,7 +7,7 @@ export default class ScopeSerializer extends JSONAPISerializer {
     const { localizedFields = [] } = snapshot.record;
 
     if (localizedFields.includes(key)) {
-      json.attributes[key] = snapshot.record.getUnlocalizedField(key);
+      json.attributes[key] = snapshot.record.localizedObjects[key];
     }
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /* eslint-disable node/no-unpublished-require */
-const { embroiderSafe, embroiderOptimized } = require("@embroider/test-setup");
+// const { embroiderSafe, embroiderOptimized } = require("@embroider/test-setup");
 const getChannelURL = require("ember-source-channel-url");
 
 module.exports = async function () {
@@ -66,8 +66,9 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      // Disable embroider for now due to: https://github.com/emberjs/data/issues/8396
+      // embroiderSafe(),
+      // embroiderOptimized(),
     ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-load-initializers": "2.1.2",
     "ember-qunit": "6.1.1",
     "ember-resolver": "10.0.0",
-    "ember-source": "4.9.1",
+    "ember-source": "4.10.0",
     "ember-source-channel-url": "3.0.0",
     "ember-template-lint": "5.3.1",
     "ember-try": "1.4.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -14,7 +14,11 @@ export default class ApplicationController extends Controller {
     this.intl.setLocale(["en", "de", "fr"]);
 
     const book = this.store.createRecord("book");
-    book.nameObject = { de: "Der Mond", en: "The Moon", fr: "La Lune" };
+    book.localizedObjects.name = {
+      de: "Der Mond",
+      en: "The Moon",
+      fr: "La Lune",
+    };
     this.book = book;
   }
 

--- a/tests/unit/models/localized-test.js
+++ b/tests/unit/models/localized-test.js
@@ -1,0 +1,56 @@
+import { setupTest } from "dummy/tests/helpers";
+import { setupIntl, setLocale } from "ember-intl/test-support";
+import { module, test } from "qunit";
+
+module("Unit | Model | localized", function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks, "en");
+
+  test("it sets value under correct locale", function (assert) {
+    const store = this.owner.lookup("service:store");
+    const model = store.createRecord("book");
+    model.name = "test-en";
+    setLocale("de");
+    model.name = "test-de";
+    setLocale("fr");
+    model.name = "test-fr";
+
+    assert.deepEqual(model.localizedObjects.name, {
+      de: "test-de",
+      en: "test-en",
+      fr: "test-fr",
+    });
+
+    setLocale("en");
+    assert.strictEqual(model.name, "test-en");
+    setLocale("de");
+    assert.strictEqual(model.name, "test-de");
+    setLocale("fr");
+    assert.strictEqual(model.name, "test-fr");
+  });
+
+  test("it respects localizedFieldLocale", function (assert) {
+    const store = this.owner.lookup("service:store");
+    const model = store.createRecord("book");
+    model.localizedObjects.name = {
+      en: "test-en",
+      de: "test-de",
+      fr: "test-fr",
+    };
+
+    assert.strictEqual(model.name, "test-en");
+
+    model.localizedFieldLocale = "de";
+    assert.strictEqual(model.name, "test-de");
+
+    model.localizedFieldLocale = "fr";
+    assert.strictEqual(model.name, "test-fr");
+  });
+
+  test("it has localizedObjects", function (assert) {
+    const store = this.owner.lookup("service:store");
+    const model = store.createRecord("book");
+
+    assert.deepEqual(model.localizedObjects.name, {});
+  });
+});

--- a/tests/unit/serializers/localized-test.js
+++ b/tests/unit/serializers/localized-test.js
@@ -1,0 +1,27 @@
+import { setupTest } from "dummy/tests/helpers";
+import { setupIntl } from "ember-intl/test-support";
+import { module, test } from "qunit";
+
+module("Unit | Serializer | localized", function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks, "en");
+
+  test("it serializes records", function (assert) {
+    const store = this.owner.lookup("service:store");
+    const record = store.createRecord("book");
+    record.name = "test";
+
+    const serializedRecord = record.serialize();
+
+    assert.deepEqual(serializedRecord, {
+      data: {
+        attributes: {
+          name: {
+            en: "test",
+          },
+        },
+        type: "books",
+      },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6167,10 +6167,10 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-4.9.1.tgz#1b5d84d753ebeab7f372dbd7f39c98123e98cd41"
-  integrity sha512-45dobRcQapTpWa6VWgDcAv6bP6iDxCVi5pJAf04NSRjDLHsjVGUCTdRslOl5rt3sX8dZJqakMnqYD2DwVjDf3A==
+ember-source@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-4.10.0.tgz#5f52bf8adacaddcbb3496d3e0df7ab3b7a31c1be"
+  integrity sha512-Y7+M+vSygMrpq4szsnpik3PxdVVA7ApuwU2L/l9Os+qpPqIKy4hT0Rw/17z4b87HNEX03jv7ueMbgcpxjUf1Kw==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
     "@babel/plugin-transform-block-scoping" "^7.16.0"


### PR DESCRIPTION
BREAKING CHANGE:
- Remove previously deprecated `getUnlocalizedField`.
- Access the localized object of an attribute via `localizedObjects.myField` instead of the magic key `myFieldObject`.

Depends on https://github.com/projectcaluma/ember-localized-model/pull/150