### PR TITLE
fix(model): use objectDefineProperty for localized attributes

### DIFF
--- a/addon/-private/models/localized.js
+++ b/addon/-private/models/localized.js
@@ -9,22 +9,21 @@ export default class LocalizedModel extends Model {
 
   get localizedObjects() {
     if (!this._localizedObjects) {
-      // Save this since the getter will have the
-      // context from the `_localizedObjects` object.
-      const context = this;
-      this._localizedObjects = this.localizedFields.reduce(
-        (localizedObjects, field) => ({
-          ...localizedObjects,
-          get [field]() {
-            return context[`_${field}`];
+      // this is not in the constructor because
+      // otherwise the environment cannot be resolved in the decorator
+      this._localizedObjects = {};
+      this.localizedFields.forEach((field) =>
+        Object.defineProperty(this._localizedObjects, field, {
+          get: () => {
+            return this[`_${field}`];
           },
-          set [field](value) {
-            context[`_${field}`] = value;
+          set: (value) => {
+            this[`_${field}`] = value;
           },
-        }),
-        {}
+        })
       );
     }
+
     return this._localizedObjects;
   }
 


### PR DESCRIPTION
fixes the bug when using multiple localizedAttr in one model only the last one would correctly work.
Reason being that spreading an object with getters/setters does not work.

fixed together with @derrabauke 